### PR TITLE
- Fixing typo in the license name in the Makefile.PL script.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use inc::Module::Install;
 name 'App-githook-perltidy';
 all_from 'lib/App/githook_perltidy.pm';
 abstract 'run perltidy and podtidy before Git commits';
-license 'gpl3';
+license 'gpl_3';
 perl_version '5.006';
 readme_from 'bin/githook-perltidy';
 


### PR DESCRIPTION
Hi Mark, please review the above change.

Many Thanks.
Best Regards,
Mohammad S Anwar
