### PR TITLE
Adds support for Perl::Tidy::Sweet

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,8 @@ requires 'Perl::Tidy'     => 0;
 requires 'Pod::Tidy'      => 0;
 requires 'Time::Piece'    => 0;
 
+requires 'Perl::Tidy::Sweet' => '1.11';
+
 test_requires 'File::Slurp' => 0;
 test_requires 'FindBin'     => 0;
 test_requires 'Path::Tiny'  => 0;

--- a/bin/githook-perltidy
+++ b/bin/githook-perltidy
@@ -46,18 +46,21 @@ the first argument:
 
 =over 4
 
-=item install [--force, -f] [MAKE ARGS]
+=item install [--force, -f] [--sweet, -s] [MAKE ARGS]
 
 Should be run from the command-line in the top-level directory of your
 repository. Writes F<pre-commit> and F<post-commit> files in the
-F<$GIT_DIR/hooks/> directory. Any MAKE ARGS given will be added to the
+F<$GIT_DIR/hooks/> directory.  Any MAKE ARGS given will be added to the
 C<githook-perltidy pre-commit> call.
+
+Will add the C<--sweet> flag to all C<pre-commit> call if C<--sweet>
+is used.
 
 This command will fail if there is no .perltidyrc file in the
 repository or if the hooks directory isn't found. It will also fail if
 either of the hook files already exist, unless C<--force> is used.
 
-=item pre-commit [MAKE ARGS]
+=item pre-commit [--sweet, -s] [MAKE ARGS]
 
 Called from a Git pre-commit hook.  Checks out your index to a
 temporary working directory. Runs L<perltidy> on any Perl files in the
@@ -65,6 +68,8 @@ Git index using the F<.perltidyrc>. If F<.podtidy-opts> exists then
 L<podtidy> will also be run on any POD files in the Git index.  Any
 tidying errors stop the commmit. Otherwise the index and your working
 tree are updated with tidied files.
+
+Will use L<Perl::Tidy::Sweet> to cleanup code if C<--sweet> is used.
 
 If any MAKE ARGS are given they will be passed to a L<make> call.  This
 way you can ensure that your code passes a C<make test> or C<make
@@ -115,7 +120,7 @@ This tool is managed via github:
 
 =head1 SEE ALSO
 
-L<githooks>(5), L<perltidy>(1), L<podtidy>(1)
+L<githooks>(5), L<perltidy>(1), L<podtidy>(1), L<perltidy-sweet>(1)
 
 =head1 AUTHOR
 

--- a/lib/App/githook_perltidy.pm
+++ b/lib/App/githook_perltidy.pm
@@ -28,9 +28,21 @@ opt force => (
     alias   => 'f',
 );
 
+opt sweet => (
+    isa     => 'Bool',
+    comment => 'Use Perl::Tidy::Sweet instead of Perl::Tidy',
+    alias   => 's',
+);
+
 subcmd(
     cmd     => 'pre-commit',
     comment => 'Run perltidy, podtidy and (optionally) tests',
+);
+
+opt sweet => (
+    isa     => 'Bool',
+    comment => 'Use Perl::Tidy::Sweet instead of Perl::Tidy',
+    alias   => 's',
 );
 
 arg make_args => (

--- a/lib/App/githook_perltidy/install.pm
+++ b/lib/App/githook_perltidy/install.pm
@@ -23,7 +23,8 @@ sub run {
         die "File/link exists: $pre_file\n" unless $opts->{force};
     }
 
-    $pre_file->spew("#!/bin/sh\n$0 pre-commit $opts->{make_args}\n");
+    my $sweet = $opts->{sweet} ? ' -s' : '';
+    $pre_file->spew("#!/bin/sh\n$0 pre-commit$sweet $opts->{make_args}\n");
     chmod 0755, $pre_file || warn "chmod: $!";
     print "$me: $pre_file";
     print " (forced)" if $opts->{force};

--- a/lib/App/githook_perltidy/pre_commit.pm
+++ b/lib/App/githook_perltidy/pre_commit.pm
@@ -26,6 +26,12 @@ sub run {
 
     $temp_dir = Path::Tiny->tempdir('githook-perltidy-XXXXXXXX');
 
+    my $perltidy = \&Perl::Tidy::perltidy;
+    if( $opts->{sweet} ){
+        require Perl::Tidy::Sweetened;
+        $perltidy = \&Perl::Tidy::Sweetened::perltidy;
+    }
+
     # Both of these start out as relative which breaks when we want to
     # modify the repo and index from a different working tree
     $ENV{GIT_DIR}        = path( $ENV{GIT_DIR} )->absolute->stringify;
@@ -93,7 +99,7 @@ sub run {
             print "  $me: perltidy INDEX/$file\n";
 
             my $error =
-              Perl::Tidy::perltidy( argv =>
+              $perltidy->( argv =>
                   [ '--profile=' . $rc, qw/-nst -b -bext=.bak/, "$tmp_file" ],
               );
 
@@ -129,7 +135,7 @@ sub run {
             unless ( $file =~ m/\.pod$/i ) {
                 print "  $me: perltidy WORK_TREE/$file $tmp_file\n";
 
-                my $error = Perl::Tidy::perltidy(
+                my $error = $perltidy->(
                     argv => [ '--profile=' . $rc, qw/-nst -b/, "$tmp_file" ], );
 
                 if ( -e $tmp_file . '.ERR' ) {

--- a/t/githook-perltidy-sweet.t
+++ b/t/githook-perltidy-sweet.t
@@ -1,0 +1,183 @@
+use strict;
+use warnings;
+use Test::More;
+use Carp qw/croak/;
+use Path::Tiny;
+use File::Slurp;
+use FindBin qw/$Bin/;
+use Test::Fatal;
+use Sys::Cmd qw/run/;
+
+plan skip_all => 'No Git' unless eval { run(qw!git --version!); 1; };
+plan skip_all => 'Optional module Perl::Tidy::Sweet not installed'
+  unless eval { require 'Perl/Tidy/Sweet.pm'; };
+
+my $githook_perltidy = path( $Bin, 'githook-perltidy' );
+my $cwd              = Path::Tiny->cwd;
+my $dir              = Path::Tiny->tempdir( CLEANUP => 1 );
+
+chdir $dir || die "chdir $dir: $!";
+note "Testing $githook_perltidy in $dir";
+
+my $hook_dir = path( '.git', 'hooks' );
+my $pre = $hook_dir->child('pre-commit');
+
+like exception { run($githook_perltidy) }, qr/^usage:/, 'usage';
+
+run(qw!git init!);
+run( qw!git config user.email!, 'you@example.com' );
+run( qw!git config user.name!,  'Your Name' );
+
+# Cannot check syntax without installing Method::Signatures::Simple
+write_file( '.perltidyrc', "-i 4\n-nsyn\n-w\n" );
+
+like exception { run( $githook_perltidy, qw!install -s! ) },
+  qr/\.perltidyrc/, '.perltidyrc check';
+
+run(qw!git add .perltidyrc!);
+run( qw!git commit -m!, 'add perltidyrc' );
+
+$pre->remove;
+
+like run( $githook_perltidy, qw!install -s! ), qr/pre-commit/s,
+  'install output';
+
+ok -e $pre, 'pre-commit exists';
+
+like exception { run( $githook_perltidy, qw!install -s! ) },
+  qr/exists/, 'existing hook files';
+
+like run( $githook_perltidy, qw!install --force -s! ),
+  qr/pre-commit \(forced\)/s, 'install --force -s';
+
+like run( $githook_perltidy, qw!install -f -s! ),
+  qr/pre-commit \(forced\)/s, 'install -f -s';
+
+my $no_indent = '#!' . $^X . '
+method test ( :$arg1, :$arg2 ) {
+print $self->dent( $arg1 );
+}
+';
+
+my $with_indent = '#!' . $^X . '
+method test ( :$arg1, :$arg2 ) {
+    print $self->dent($arg1);
+}
+';
+
+my $bad_syntax = '#!' . $^X . '
+if (1) {
+not really perl;
+';
+
+write_file( 'file', $no_indent );
+run(qw!git add file!);
+run( qw!git commit -m!, 'add file' );
+is read_file('file'), $with_indent, 'detect no-extension';
+
+write_file( 'file.pl', $no_indent );
+run(qw!git add file.pl!);
+run( qw!git commit -m!, 'add file.pl' );
+is read_file('file.pl'), $with_indent, 'detect .pl extension';
+
+write_file( 'bad.pl', $bad_syntax );
+run(qw!git add bad.pl!);
+ok exception { run( qw!git commit -m!, 'bad syntax' ) },
+  'commit stopped on bad syntax';
+
+is read_file('bad.pl'), $bad_syntax, 'working tree restored';
+like run(qw!git status --porcelain!), qr/^A\s+bad.pl$/sm, 'index status';
+unlink 'bad.pl';
+run(qw!git checkout-index bad.pl!);
+is read_file('bad.pl'), $bad_syntax, 'index contents';
+run(qw!git reset!);
+
+# .podtidy-opts
+
+write_file( '.podtidy-opts', "--columns 10\n" );
+
+my $long_pod = "
+=head1 title
+
+This is a rather long line, well at least longer than 10 characters
+";
+
+write_file( 'x.pod', $long_pod );
+run(qw!git add x.pod!);
+
+like exception { run( qw!git commit -m!, 'add .podtidy-opts' ) },
+  qr/.podtidy-opts/, '.podtidy-opts check';
+
+run(qw!git reset!);
+
+run(qw!git add .podtidy-opts!);
+run( qw!git commit -m!, 'add .podtidy-opts' );
+
+run(qw!git add x.pod!);
+run( qw!git commit -m!, 'add x.pod' );
+
+my $short_pod = "
+=head1 title
+
+This is a
+rather
+long
+line,
+well at
+least
+longer
+than 10
+characters
+
+";
+
+is scalar read_file('x.pod'), $short_pod, 'podtidy';
+
+SKIP: {
+    skip 'No make found', 7 unless eval { run(qw/make --version/); 1; };
+
+    $pre->remove;
+
+    write_file(
+        'Makefile.PL', "
+use ExtUtils::MakeMaker;
+
+WriteMakefile(
+   NAME            => 'Your::Module',
+);
+"
+    );
+
+    like run( $githook_perltidy, qw!install -s test ATTRIBUTE=1! ),
+      qr/pre-commit/s, 'install make args output';
+
+    like read_file($pre), qr/pre-commit -s test ATTRIBUTE=1/,
+      'pre content make args ';
+
+    run(qw!git add Makefile.PL!);
+    like run( qw!git commit -m!, 'add Makefile.PL' ),
+      qr/add Makefile.PL/sm,
+      'make run';
+    ok -e 'Makefile', 'perl Makefile.PL';
+
+    unlink 'Makefile';
+    run(qw!git reset HEAD^!);
+    run(qw!git add Makefile.PL!);
+    like run(
+        qw!git commit -m!,
+        { env => { PERLTIDY_MAKE => '' } },
+        'add Makefile.PL'
+      ),
+      qr/add Makefile.PL/sm,
+      'no make run';
+    ok !-e 'Makefile', 'no perl Makefile.PL';
+}
+
+done_testing();
+
+# Make sure we get out of the tempdir before it is cleaned up
+END {
+    chdir $cwd if $cwd;
+    undef $dir;
+}
+


### PR DESCRIPTION
Perl::Tidy::Sweet uses Perl::Tidy's prefilter and postfilter hooks to
support syntax added by a number of modules (p5-mop,
Method::Signatures::Simple, MooseX::Method::Signatures, MooseX::Declare,
etc).  This includes method and func keywords, including the (possibly
multi-line) parameter lists.

This patch adds a --sweet/-s flag to both the install and pre-commit
commands. When specified, code is tied with Perl::Tidy::Sweet instead of
Perl::Tidy.

Perl::Tidy::Sweet is added as a prereq in the Makefile.PL, as
"recommends" doesn't seem to do anything (I'm not that familiar with
Module::Install).

A new test has been added that optionally runs all the tests with the
--sweet flag. This might be overkill. It would probably be sufficient to
just test the tidying of code with the method keyword.

This is my contribution to May's PRC. I just happen to be the author of
Perl::Tidy::Sweet.
